### PR TITLE
Add SQLite session storage and token refresh

### DIFF
--- a/lib/core/di.dart
+++ b/lib/core/di.dart
@@ -2,11 +2,13 @@ import 'package:get_it/get_it.dart';
 import 'package:http/http.dart' as http;
 
 import '../features/auth/data/datasources/auth_remote_datasource.dart';
+import '../features/auth/data/datasources/auth_local_datasource.dart';
 import '../features/auth/data/repositories/auth_repository_impl.dart';
 import '../features/auth/domain/repositories/auth_repository.dart';
 import '../features/auth/domain/usecases/login_user.dart';
 import '../features/auth/ui/blocs/auth_bloc/auth_bloc.dart';
 import 'network/auth_api.dart';
+import 'network/token_refresher.dart';
 
 final sl = GetIt.instance;
 
@@ -21,10 +23,16 @@ Future<void> init() async {
       baseUrl: baseUrl,
     ),
   );
+  sl.registerLazySingleton<AuthLocalDataSource>(() => AuthLocalDataSource());
 
   // Repository
   sl.registerLazySingleton<AuthRepository>(
-        () => AuthRepositoryImpl(sl()),
+        () => AuthRepositoryImpl(sl(), sl()),
+  );
+
+  // Token refresher
+  sl.registerLazySingleton(
+        () => TokenRefresher(repository: sl<AuthRepository>(), localDataSource: sl<AuthLocalDataSource>()),
   );
 
   // Use cases

--- a/lib/core/network/auth_api.dart
+++ b/lib/core/network/auth_api.dart
@@ -3,6 +3,7 @@ import 'package:http/http.dart' as http;
 
 import '../../features/auth/data/datasources/auth_remote_datasource.dart';
 import '../../features/auth/data/models/auth_tokens_model.dart';
+import '../../features/auth/data/models/login_response_model.dart';
 import '../../features/auth/data/models/user.dart';
 
 
@@ -16,7 +17,7 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
   });
 
   @override
-  Future<UserModel> login(String email, String password) async {
+  Future<LoginResponseModel> login(String email, String password) async {
     final loginUrl = Uri.parse('$baseUrl/auth/login');
 
     final loginResponse = await client.post(
@@ -46,7 +47,9 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
       throw Exception('Error al obtener usuario: ${userResponse.body}');
     }
 
-    return UserModel.fromJson(jsonDecode(userResponse.body));
+    final user = UserModel.fromJson(jsonDecode(userResponse.body));
+
+    return LoginResponseModel(user: user, tokens: tokens);
   }
 
   @override

--- a/lib/core/network/token_refresher.dart
+++ b/lib/core/network/token_refresher.dart
@@ -1,0 +1,31 @@
+import 'dart:async';
+
+import '../../features/auth/data/datasources/auth_local_datasource.dart';
+import '../../features/auth/data/models/auth_tokens_model.dart';
+import '../../features/auth/domain/repositories/auth_repository.dart';
+
+class TokenRefresher {
+  final AuthRepository repository;
+  final AuthLocalDataSource localDataSource;
+  Timer? _timer;
+
+  TokenRefresher({required this.repository, required this.localDataSource});
+
+  Future<void> start() async {
+    _timer?.cancel();
+    _timer = Timer.periodic(const Duration(minutes: 55), (_) async {
+      final tokens = await localDataSource.getTokens();
+      if (tokens == null) return;
+      try {
+        final newAccess = await repository.refreshToken(tokens.refreshToken);
+        await localDataSource.saveTokens(
+          AuthTokensModel(accessToken: newAccess, refreshToken: tokens.refreshToken),
+        );
+      } catch (_) {}
+    });
+  }
+
+  void stop() {
+    _timer?.cancel();
+  }
+}

--- a/lib/features/auth/data/datasources/auth_local_datasource.dart
+++ b/lib/features/auth/data/datasources/auth_local_datasource.dart
@@ -1,0 +1,51 @@
+import 'package:path/path.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:sqflite/sqflite.dart';
+
+import '../models/auth_tokens_model.dart';
+
+class AuthLocalDataSource {
+  static const _dbName = 'auth.db';
+  static const _table = 'session';
+  Database? _db;
+
+  Future<Database> get _database async {
+    if (_db != null) return _db!;
+    final dir = await getApplicationDocumentsDirectory();
+    final path = join(dir.path, _dbName);
+    _db = await openDatabase(
+      path,
+      version: 1,
+      onCreate: (db, version) async {
+        await db.execute('CREATE TABLE $_table(id INTEGER PRIMARY KEY, accessToken TEXT, refreshToken TEXT)');
+      },
+    );
+    return _db!;
+  }
+
+  Future<void> saveTokens(AuthTokensModel tokens) async {
+    final db = await _database;
+    await db.delete(_table);
+    await db.insert(_table, {
+      'id': 1,
+      'accessToken': tokens.accessToken,
+      'refreshToken': tokens.refreshToken,
+    });
+  }
+
+  Future<AuthTokensModel?> getTokens() async {
+    final db = await _database;
+    final data = await db.query(_table, where: 'id = ?', whereArgs: [1]);
+    if (data.isEmpty) return null;
+    final map = data.first;
+    return AuthTokensModel(
+      accessToken: map['accessToken'] as String,
+      refreshToken: map['refreshToken'] as String,
+    );
+  }
+
+  Future<void> clearTokens() async {
+    final db = await _database;
+    await db.delete(_table);
+  }
+}

--- a/lib/features/auth/data/datasources/auth_remote_datasource.dart
+++ b/lib/features/auth/data/datasources/auth_remote_datasource.dart
@@ -1,7 +1,8 @@
 import '../models/user.dart';
+import '../models/login_response_model.dart';
 
 abstract class AuthRemoteDataSource {
-  Future<UserModel> login(String email, String password);
+  Future<LoginResponseModel> login(String email, String password);
   Future<void> register(String email, String password);
   Future<String> refreshToken(String refreshToken);
 }

--- a/lib/features/auth/data/models/login_response_model.dart
+++ b/lib/features/auth/data/models/login_response_model.dart
@@ -1,0 +1,8 @@
+import 'user.dart';
+import 'auth_tokens_model.dart';
+
+class LoginResponseModel {
+  final UserModel user;
+  final AuthTokensModel tokens;
+  LoginResponseModel({required this.user, required this.tokens});
+}

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -1,14 +1,24 @@
 import '../../domain/repositories/auth_repository.dart';
 import '../datasources/auth_remote_datasource.dart';
+import '../datasources/auth_local_datasource.dart';
+import '../models/login_response_model.dart';
 import '../models/user.dart';
 
 class AuthRepositoryImpl implements AuthRepository {
   final AuthRemoteDataSource remoteDataSource;
+  final AuthLocalDataSource localDataSource;
 
-  AuthRepositoryImpl(this.remoteDataSource);
+  AuthRepositoryImpl(this.remoteDataSource, this.localDataSource);
 
   @override
-  Future<UserModel> login(String email, String password) => remoteDataSource.login(email, password);
+  Future<UserModel> login(String email, String password, bool rememberMe) async {
+    final LoginResponseModel response =
+        await remoteDataSource.login(email, password);
+    if (rememberMe) {
+      await localDataSource.saveTokens(response.tokens);
+    }
+    return response.user;
+  }
 
   @override
   Future<void> register(String email, String password) => remoteDataSource.register(email, password);

--- a/lib/features/auth/domain/repositories/auth_repository.dart
+++ b/lib/features/auth/domain/repositories/auth_repository.dart
@@ -1,7 +1,7 @@
 import '../entities/user.dart';
 
 abstract class AuthRepository {
-  Future<User> login(String email, String password);
+  Future<User> login(String email, String password, bool rememberMe);
   Future<void> register(String email, String password);
   Future<String> refreshToken(String refreshToken);
 }

--- a/lib/features/auth/domain/usecases/login_user.dart
+++ b/lib/features/auth/domain/usecases/login_user.dart
@@ -5,5 +5,6 @@ class LoginUser {
   final AuthRepository repository;
   LoginUser(this.repository);
 
-  Future<User> call(String email, String password) => repository.login(email, password);
+  Future<User> call(String email, String password, bool rememberMe) =>
+      repository.login(email, password, rememberMe);
 }

--- a/lib/features/auth/ui/blocs/auth_bloc/auth_bloc.dart
+++ b/lib/features/auth/ui/blocs/auth_bloc/auth_bloc.dart
@@ -3,6 +3,8 @@ import 'package:equatable/equatable.dart';
 
 import '../../../domain/entities/user.dart';
 import '../../../domain/usecases/login_user.dart';
+import '../../../../core/di.dart';
+import '../../../../core/network/token_refresher.dart';
 
 part 'auth_event.dart';
 part 'auth_state.dart';
@@ -14,7 +16,11 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
     on<LoginRequested>((event, emit) async {
       emit(AuthLoading());
       try {
-        final user = await loginUser(event.email, event.password);
+        final user =
+            await loginUser(event.email, event.password, event.rememberMe);
+        if (event.rememberMe) {
+          await sl<TokenRefresher>().start();
+        }
         emit(Authenticated(user));
       } catch (e) {
         emit(AuthError(e.toString()));

--- a/lib/features/auth/ui/blocs/auth_bloc/auth_event.dart
+++ b/lib/features/auth/ui/blocs/auth_bloc/auth_event.dart
@@ -4,5 +4,6 @@ sealed class AuthEvent {}
 class LoginRequested extends AuthEvent {
   final String email;
   final String password;
-  LoginRequested(this.email, this.password);
+  final bool rememberMe;
+  LoginRequested(this.email, this.password, this.rememberMe);
 }

--- a/lib/features/auth/ui/screens/login_screen.dart
+++ b/lib/features/auth/ui/screens/login_screen.dart
@@ -127,9 +127,10 @@ class LoginScreen extends StatelessWidget {
                                     ? null
                                     : () {
                                   context.read<AuthBloc>().add(
-                                    LoginRequested(
+                                  LoginRequested(
                                       _emailCtrl.text,
                                       _pwdCtrl.text,
+                                      _rememberMe.value,
                                     ),
                                   );
                                 },

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,10 +2,12 @@ import 'package:flutter/material.dart';
 
 import 'core/di.dart' as di;
 import 'core/routes/routes.dart';
+import 'core/network/token_refresher.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await di.init();
+  await di.sl<TokenRefresher>().start();
   runApp(const MyApp());
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,9 @@ dependencies:
   flutter_bloc: ^8.1.6
   http: ^1.2.1
   get_it: ^8.0.3
+  sqflite: ^2.3.0
+  path_provider: ^2.1.1
+  path: ^1.8.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add SQLite local data source and token refresher
- return login response with tokens
- persist tokens when "remember me" is checked
- refresh tokens periodically
- start refresher on app startup

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f4e5144d0832cb54b2caf49a55f24