### PR TITLE
Implement league create and join use cases

### DIFF
--- a/lib/core/di.dart
+++ b/lib/core/di.dart
@@ -12,6 +12,9 @@ import '../features/leagues/data/datasources/leagues_remote_datasource.dart';
 import '../features/leagues/data/repositories/leagues_repository_impl.dart';
 import '../features/leagues/domain/repositories/leagues_repository.dart';
 import '../features/leagues/domain/usecases/get_leagues_for_user.dart';
+import '../features/leagues/domain/usecases/create_league.dart';
+import '../features/leagues/domain/usecases/join_league.dart';
+import '../features/leagues/ui/blocs/leagues_bloc/leagues_bloc.dart';
 import '../features/app_context/ui/blocs/app_context_bloc/app_context_bloc.dart';
 import '../features/matches/data/datasources/matches_remote_datasource.dart';
 import '../features/matches/data/repositories/matches_repository_impl.dart';
@@ -75,6 +78,8 @@ Future<void> init() async {
   sl.registerLazySingleton(() => CancelParticipation(sl()));
   sl.registerLazySingleton(() => UpdateMatchResult(sl()));
   sl.registerLazySingleton(() => GetLeaguesForUser(sl()));
+  sl.registerLazySingleton(() => CreateLeague(sl()));
+  sl.registerLazySingleton(() => JoinLeague(sl()));
 
   // Blocs
   sl.registerFactory(() => AuthBloc(loginUser: sl<LoginUser>()));
@@ -88,5 +93,10 @@ Future<void> init() async {
   sl.registerFactory(() => AppContextBloc(
         localDataSource: sl<AuthLocalDataSource>(),
         getLeaguesForUser: sl<GetLeaguesForUser>(),
+      ));
+  sl.registerFactory(() => LeaguesBloc(
+        createLeague: sl<CreateLeague>(),
+        joinLeague: sl<JoinLeague>(),
+        localDataSource: sl<AuthLocalDataSource>(),
       ));
 }

--- a/lib/features/app_context/ui/screens/league_selection_screen.dart
+++ b/lib/features/app_context/ui/screens/league_selection_screen.dart
@@ -1,4 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../../core/di.dart';
+import '../../../leagues/ui/blocs/leagues_bloc/leagues_bloc.dart';
 
 class LeagueSelectionScreen extends StatelessWidget {
   const LeagueSelectionScreen({super.key});
@@ -8,37 +12,66 @@ class LeagueSelectionScreen extends StatelessWidget {
     final codeCtrl = TextEditingController();
     final nameCtrl = TextEditingController();
 
-    return Scaffold(
-      appBar: AppBar(title: const Text('Selecciona liga')),
-      body: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          children: [
-            TextField(
-              controller: codeCtrl,
-              decoration: const InputDecoration(
-                labelText: 'Código de invitación',
+    return BlocProvider(
+      create: (_) => sl<LeaguesBloc>(),
+      child: BlocConsumer<LeaguesBloc, LeaguesState>(
+        listener: (context, state) {
+          if (state is LeagueLoaded) {
+            Navigator.of(context).pushReplacementNamed('/home');
+          } else if (state is LeaguesError) {
+            ScaffoldMessenger.of(context)
+                .showSnackBar(SnackBar(content: Text(state.message)));
+          }
+        },
+        builder: (context, state) {
+          final loading = state is LeaguesLoading;
+          return Scaffold(
+            appBar: AppBar(title: const Text('Selecciona liga')),
+            body: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                children: [
+                  TextField(
+                    controller: codeCtrl,
+                    decoration: const InputDecoration(
+                      labelText: 'Código de invitación',
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  ElevatedButton(
+                    onPressed: loading
+                        ? null
+                        : () {
+                            context
+                                .read<LeaguesBloc>()
+                                .add(JoinLeagueRequested(codeCtrl.text));
+                          },
+                    child:
+                        Text(loading ? 'Uniendo...' : 'Unirse a liga'),
+                  ),
+                  const Divider(height: 32),
+                  TextField(
+                    controller: nameCtrl,
+                    decoration: const InputDecoration(
+                      labelText: 'Nombre de la liga',
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  ElevatedButton(
+                    onPressed: loading
+                        ? null
+                        : () {
+                            context
+                                .read<LeaguesBloc>()
+                                .add(CreateLeagueRequested(nameCtrl.text));
+                          },
+                    child: Text(loading ? 'Creando...' : 'Crear liga'),
+                  ),
+                ],
               ),
             ),
-            const SizedBox(height: 16),
-            ElevatedButton(
-              onPressed: () {},
-              child: const Text('Unirse a liga'),
-            ),
-            const Divider(height: 32),
-            TextField(
-              controller: nameCtrl,
-              decoration: const InputDecoration(
-                labelText: 'Nombre de la liga',
-              ),
-            ),
-            const SizedBox(height: 16),
-            ElevatedButton(
-              onPressed: () {},
-              child: const Text('Crear liga'),
-            ),
-          ],
-        ),
+          );
+        },
       ),
     );
   }

--- a/lib/features/leagues/data/datasources/leagues_remote_datasource.dart
+++ b/lib/features/leagues/data/datasources/leagues_remote_datasource.dart
@@ -5,6 +5,10 @@ import '../models/league_model.dart';
 
 abstract class LeaguesRemoteDataSource {
   Future<List<LeagueModel>> getLeaguesForUser(String userId, String token);
+  Future<LeagueModel> createLeague(
+      Map<String, dynamic> request, String token);
+  Future<LeagueModel> joinLeague(
+      String leagueId, Map<String, dynamic> request, String token);
 }
 
 class LeaguesRemoteDataSourceImpl implements LeaguesRemoteDataSource {
@@ -24,5 +28,41 @@ class LeaguesRemoteDataSourceImpl implements LeaguesRemoteDataSource {
     }
     final data = jsonDecode(response.body) as List<dynamic>;
     return data.map((e) => LeagueModel.fromJson(e)).toList();
+  }
+
+  @override
+  Future<LeagueModel> createLeague(
+      Map<String, dynamic> request, String token) async {
+    final url = Uri.parse('$baseUrl/leagues');
+    final response = await client.post(
+      url,
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer $token',
+      },
+      body: jsonEncode(request),
+    );
+    if (response.statusCode != 200) {
+      throw Exception('Error al crear liga: ${response.body}');
+    }
+    return LeagueModel.fromJson(jsonDecode(response.body));
+  }
+
+  @override
+  Future<LeagueModel> joinLeague(
+      String leagueId, Map<String, dynamic> request, String token) async {
+    final url = Uri.parse('$baseUrl/leagues/$leagueId/join');
+    final response = await client.post(
+      url,
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer $token',
+      },
+      body: jsonEncode(request),
+    );
+    if (response.statusCode != 200) {
+      throw Exception('Error al unirse a la liga: ${response.body}');
+    }
+    return LeagueModel.fromJson(jsonDecode(response.body));
   }
 }

--- a/lib/features/leagues/data/repositories/leagues_repository_impl.dart
+++ b/lib/features/leagues/data/repositories/leagues_repository_impl.dart
@@ -10,4 +10,14 @@ class LeaguesRepositoryImpl implements LeaguesRepository {
   @override
   Future<List<League>> getLeaguesForUser(String userId, String token) =>
       remoteDataSource.getLeaguesForUser(userId, token);
+
+  @override
+  Future<League> createLeague(
+          Map<String, dynamic> request, String token) =>
+      remoteDataSource.createLeague(request, token);
+
+  @override
+  Future<League> joinLeague(
+          String leagueId, Map<String, dynamic> request, String token) =>
+      remoteDataSource.joinLeague(leagueId, request, token);
 }

--- a/lib/features/leagues/domain/repositories/leagues_repository.dart
+++ b/lib/features/leagues/domain/repositories/leagues_repository.dart
@@ -2,4 +2,8 @@ import '../entities/league.dart';
 
 abstract class LeaguesRepository {
   Future<List<League>> getLeaguesForUser(String userId, String token);
+  Future<League> createLeague(
+      Map<String, dynamic> request, String token);
+  Future<League> joinLeague(
+      String leagueId, Map<String, dynamic> request, String token);
 }

--- a/lib/features/leagues/domain/usecases/create_league.dart
+++ b/lib/features/leagues/domain/usecases/create_league.dart
@@ -1,0 +1,10 @@
+import '../entities/league.dart';
+import '../repositories/leagues_repository.dart';
+
+class CreateLeague {
+  final LeaguesRepository repository;
+  CreateLeague(this.repository);
+
+  Future<League> call(Map<String, dynamic> request, String token) =>
+      repository.createLeague(request, token);
+}

--- a/lib/features/leagues/domain/usecases/join_league.dart
+++ b/lib/features/leagues/domain/usecases/join_league.dart
@@ -1,0 +1,10 @@
+import '../entities/league.dart';
+import '../repositories/leagues_repository.dart';
+
+class JoinLeague {
+  final LeaguesRepository repository;
+  JoinLeague(this.repository);
+
+  Future<League> call(String leagueId, Map<String, dynamic> request, String token) =>
+      repository.joinLeague(leagueId, request, token);
+}

--- a/lib/features/leagues/ui/blocs/leagues_bloc/leagues_bloc.dart
+++ b/lib/features/leagues/ui/blocs/leagues_bloc/leagues_bloc.dart
@@ -1,0 +1,68 @@
+import 'dart:convert';
+
+import 'package:bloc/bloc.dart';
+import '../../../../auth/data/datasources/auth_local_datasource.dart';
+import '../../../domain/entities/league.dart';
+import '../../../domain/usecases/create_league.dart';
+import '../../../domain/usecases/join_league.dart';
+
+part 'leagues_event.dart';
+part 'leagues_state.dart';
+
+class LeaguesBloc extends Bloc<LeaguesEvent, LeaguesState> {
+  final CreateLeague createLeague;
+  final JoinLeague joinLeague;
+  final AuthLocalDataSource localDataSource;
+
+  LeaguesBloc({
+    required this.createLeague,
+    required this.joinLeague,
+    required this.localDataSource,
+  }) : super(LeaguesInitial()) {
+    on<CreateLeagueRequested>(_onCreate);
+    on<JoinLeagueRequested>(_onJoin);
+  }
+
+  Future<void> _onCreate(
+      CreateLeagueRequested event, Emitter<LeaguesState> emit) async {
+    emit(LeaguesLoading());
+    try {
+      final tokens = await localDataSource.getTokens();
+      if (tokens == null) throw Exception('Sesión no encontrada');
+      final userId = _extractUserIdFromToken(tokens.accessToken);
+      final league = await createLeague(
+        {'name': event.name, 'createdBy': userId},
+        tokens.accessToken,
+      );
+      emit(LeagueLoaded(league));
+    } catch (e) {
+      emit(LeaguesError(e.toString()));
+    }
+  }
+
+  Future<void> _onJoin(
+      JoinLeagueRequested event, Emitter<LeaguesState> emit) async {
+    emit(LeaguesLoading());
+    try {
+      final tokens = await localDataSource.getTokens();
+      if (tokens == null) throw Exception('Sesión no encontrada');
+      final userId = _extractUserIdFromToken(tokens.accessToken);
+      final league = await joinLeague(
+        event.leagueId,
+        {'userId': userId},
+        tokens.accessToken,
+      );
+      emit(LeagueLoaded(league));
+    } catch (e) {
+      emit(LeaguesError(e.toString()));
+    }
+  }
+
+  String _extractUserIdFromToken(String token) {
+    final parts = token.split('.');
+    if (parts.length != 3) throw Exception('Token inválido');
+    final payload = utf8.decode(base64Url.decode(base64Url.normalize(parts[1])));
+    final decoded = jsonDecode(payload) as Map<String, dynamic>;
+    return decoded['sub'] as String;
+  }
+}

--- a/lib/features/leagues/ui/blocs/leagues_bloc/leagues_event.dart
+++ b/lib/features/leagues/ui/blocs/leagues_bloc/leagues_event.dart
@@ -1,0 +1,13 @@
+part of 'leagues_bloc.dart';
+
+abstract class LeaguesEvent {}
+
+class CreateLeagueRequested extends LeaguesEvent {
+  final String name;
+  CreateLeagueRequested(this.name);
+}
+
+class JoinLeagueRequested extends LeaguesEvent {
+  final String leagueId;
+  JoinLeagueRequested(this.leagueId);
+}

--- a/lib/features/leagues/ui/blocs/leagues_bloc/leagues_state.dart
+++ b/lib/features/leagues/ui/blocs/leagues_bloc/leagues_state.dart
@@ -1,0 +1,17 @@
+part of 'leagues_bloc.dart';
+
+abstract class LeaguesState {}
+
+class LeaguesInitial extends LeaguesState {}
+
+class LeaguesLoading extends LeaguesState {}
+
+class LeagueLoaded extends LeaguesState {
+  final League league;
+  LeagueLoaded(this.league);
+}
+
+class LeaguesError extends LeaguesState {
+  final String message;
+  LeaguesError(this.message);
+}


### PR DESCRIPTION
## Summary
- add create/join league endpoints in datasource and repository
- expose new league use cases
- implement LeaguesBloc for creating and joining leagues
- wire up dependency injection
- update league selection screen with bloc logic

## Testing
- `flutter analyze` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855d51b5974832c96f841167f40f48a