### PR TITLE
Refactor widgets for reuse

### DIFF
--- a/lib/core/styles/app_colors.dart
+++ b/lib/core/styles/app_colors.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/material.dart';
+
+class AppColors {
+  static const Color primary = Colors.blue;
+  static const Color accent = Color(0xFF26EC77);
+  static const Color background = Color(0xFFF4F6FA);
+  static const Color inputFill = Color(0xFFF4F6FA);
+}

--- a/lib/core/styles/input_decoration.dart
+++ b/lib/core/styles/input_decoration.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
+import 'app_colors.dart';
 
 InputDecoration customInputDecoration(String placeholder) {
   return InputDecoration(
     hintText: placeholder,
     filled: true,
-    fillColor: const Color(0xFFF5F7FC),
+    fillColor: AppColors.inputFill,
     contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 18),
     border: OutlineInputBorder(
       borderRadius: BorderRadius.circular(14),
@@ -12,3 +13,4 @@ InputDecoration customInputDecoration(String placeholder) {
     ),
   );
 }
+

--- a/lib/core/widgets/circle_logo.dart
+++ b/lib/core/widgets/circle_logo.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../styles/app_colors.dart';
 
 class CircleLogo extends StatelessWidget {
   final double size;
@@ -14,7 +15,7 @@ class CircleLogo extends StatelessWidget {
       padding: const EdgeInsets.all(16),
       decoration: const BoxDecoration(
         shape: BoxShape.circle,
-        color: Color(0xFFF5F7FC),
+        color: AppColors.inputFill,
       ),
       child: Image.asset(assetPath),
     );

--- a/lib/core/widgets/fut_button.dart
+++ b/lib/core/widgets/fut_button.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+import '../styles/app_colors.dart';
+
+class FutButton extends StatelessWidget {
+  final String text;
+  final VoidCallback? onPressed;
+  final bool loading;
+  final String? loadingText;
+  final Color color;
+  final Color textColor;
+  final Color? borderColor;
+
+  const FutButton({
+    super.key,
+    required this.text,
+    required this.onPressed,
+    this.loading = false,
+    this.loadingText,
+    this.color = AppColors.primary,
+    this.textColor = Colors.white,
+    this.borderColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      child: ElevatedButton(
+        style: ElevatedButton.styleFrom(
+          backgroundColor: color,
+          minimumSize: const Size.fromHeight(48),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(24),
+            side: borderColor != null
+                ? BorderSide(color: borderColor!)
+                : BorderSide.none,
+          ),
+        ),
+        onPressed: loading ? null : onPressed,
+        child: Text(
+          loading ? (loadingText ?? text) : text,
+          style: TextStyle(color: textColor),
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/features/app_context/ui/screens/league_selection_screen.dart
+++ b/lib/features/app_context/ui/screens/league_selection_screen.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../../../../core/di.dart';
+import '../../../../core/styles/app_colors.dart';
+import '../../../../core/styles/input_decoration.dart';
+import '../../../../core/widgets/fut_button.dart';
 import '../../../leagues/ui/blocs/leagues_bloc/leagues_bloc.dart';
 
 class LeagueSelectionScreen extends StatelessWidget {
@@ -12,9 +15,6 @@ class LeagueSelectionScreen extends StatelessWidget {
     final codeCtrl = TextEditingController();
     final nameCtrl = TextEditingController();
 
-    final primaryColor = Colors.blue;
-    final accentColor = const Color(0xFF26EC77);
-    final backgroundColor = const Color(0xFFF4F6FA);
 
     return BlocProvider(
       create: (_) => sl<LeaguesBloc>(),
@@ -32,7 +32,7 @@ class LeagueSelectionScreen extends StatelessWidget {
           final loading = state is LeaguesLoading;
 
           return Scaffold(
-            backgroundColor: backgroundColor,
+            backgroundColor: AppColors.background,
             body: SafeArea(
               child: Center(
                 child: SingleChildScrollView(
@@ -79,33 +79,19 @@ class LeagueSelectionScreen extends StatelessWidget {
                         const SizedBox(height: 8),
                         TextField(
                           controller: nameCtrl,
-                          decoration: InputDecoration(
-                            hintText: 'Nombre de la liga',
-                            filled: true,
-                            fillColor: const Color(0xFFF4F6FA),
-                            border: OutlineInputBorder(
-                              borderRadius: BorderRadius.circular(12),
-                              borderSide: BorderSide.none,
-                            ),
-                          ),
+                          decoration:
+                              customInputDecoration('Nombre de la liga'),
                         ),
                         const SizedBox(height: 16),
-                        ElevatedButton(
-                          style: ElevatedButton.styleFrom(
-                            backgroundColor: primaryColor,
-                            minimumSize: const Size.fromHeight(48),
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(24),
-                            ),
-                          ),
-                          onPressed: loading
-                              ? null
-                              : () {
+                        FutButton(
+                          text: 'Crear liga',
+                          loadingText: 'Creando...',
+                          loading: loading,
+                          onPressed: () {
                             context.read<LeaguesBloc>().add(
                               CreateLeagueRequested(nameCtrl.text),
                             );
                           },
-                          child: Text(loading ? 'Creando...' : 'Crear liga',style: TextStyle(color: Colors.white),),
                         ),
 
                         const SizedBox(height: 32),
@@ -120,34 +106,22 @@ class LeagueSelectionScreen extends StatelessWidget {
                         const SizedBox(height: 8),
                         TextField(
                           controller: codeCtrl,
-                          decoration: InputDecoration(
-                            hintText: 'Código de invitación',
-                            filled: true,
-                            fillColor: const Color(0xFFF4F6FA),
-                            border: OutlineInputBorder(
-                              borderRadius: BorderRadius.circular(12),
-                              borderSide: BorderSide.none,
-                            ),
-                          ),
+                          decoration:
+                              customInputDecoration('Código de invitación'),
                         ),
                         const SizedBox(height: 16),
-                        ElevatedButton(
-                          style: ElevatedButton.styleFrom(
-                            backgroundColor: Colors.white,
-                            minimumSize: const Size.fromHeight(48),
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(24),
-                              side: BorderSide(color: primaryColor, width: 1),
-                            ),
-                          ),
-                          onPressed: loading
-                              ? null
-                              : () {
+                        FutButton(
+                          text: 'Unirse a liga',
+                          loadingText: 'Uniendo...',
+                          loading: loading,
+                          color: Colors.white,
+                          borderColor: AppColors.primary,
+                          textColor: AppColors.primary,
+                          onPressed: () {
                             context.read<LeaguesBloc>().add(
                               JoinLeagueRequested(codeCtrl.text),
                             );
                           },
-                          child: Text(loading ? 'Uniendo...' : 'Unirse a liga',style: TextStyle(color: primaryColor),),
                         ),
 
 

--- a/lib/features/auth/ui/screens/login_screen.dart
+++ b/lib/features/auth/ui/screens/login_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:futmatch_frontend/core/di.dart';
+import 'package:futmatch_frontend/core/styles/app_colors.dart';
 import 'package:futmatch_frontend/core/styles/input_decoration.dart';
 import 'package:futmatch_frontend/core/widgets/circle_logo.dart';
 import 'package:futmatch_frontend/core/widgets/gradient_button.dart';
@@ -19,7 +20,7 @@ class LoginScreen extends StatelessWidget {
     final theme = Theme.of(context);
 
     return Scaffold(
-      backgroundColor: const Color(0xFFF4F6FA),
+      backgroundColor: AppColors.background,
       body: BlocProvider(
         create: (_) => sl<AuthBloc>(),
         child: Builder(


### PR DESCRIPTION
## Summary
- centralize colors in `AppColors`
- create `FutButton` widget for rounded buttons
- update `LeagueSelectionScreen` to use new widgets
- use `AppColors` in login screen and circle logo

## Testing
- `dart` and `flutter` commands were unavailable so no tests were run

------
https://chatgpt.com/codex/tasks/task_e_6855e45c55a4832c90370e57ac3273ef