### PR TITLE
Implement league selector

### DIFF
--- a/lib/core/di.dart
+++ b/lib/core/di.dart
@@ -97,6 +97,7 @@ Future<void> init() async {
   sl.registerFactory(() => LeaguesBloc(
         createLeague: sl<CreateLeague>(),
         joinLeague: sl<JoinLeague>(),
+        getLeaguesForUser: sl<GetLeaguesForUser>(),
         localDataSource: sl<AuthLocalDataSource>(),
       ));
 }

--- a/lib/core/routes/routes.dart
+++ b/lib/core/routes/routes.dart
@@ -4,10 +4,12 @@ import 'package:futmatch_frontend/core/widgets/main_navbar.dart';
 import '../../features/app_context/ui/screens/splash_screen.dart';
 import '../../features/app_context/ui/screens/league_selection_screen.dart';
 import '../../features/auth/ui/screens/login_screen.dart';
+import '../../features/leagues/ui/screens/create_league_screen.dart';
 
 Map<String, Widget Function(BuildContext)> routes = {
   '/': (context) => const SplashScreen(),
   '/login': (context) => LoginScreen(),
   '/home': (context) => const MainNavbar(),
   '/league-selection': (context) => const LeagueSelectionScreen(),
+  '/create-league': (context) => const CreateLeagueScreen(),
 };

--- a/lib/core/widgets/main_navbar.dart
+++ b/lib/core/widgets/main_navbar.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:futmatch_frontend/features/matches/ui/screens/matches_screen.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../../features/home/ui/screens/home_screen.dart';
+import '../../features/leagues/ui/blocs/leagues_bloc/leagues_bloc.dart';
+import 'package:futmatch_frontend/core/di.dart';
 
 
 
@@ -15,54 +18,57 @@ class MainNavbar extends StatefulWidget {
 class _MainNavbarState extends State<MainNavbar> {
   int _currentIndex = 0;
 
-  final List<Widget> _screens = const [
-    HomeScreen(),
-    MatchesScreen()
+  final List<Widget> _screens = [
+    const HomeScreen(),
+    const MatchesScreen()
   ];
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.white, // Fondo blanco total
-      body: IndexedStack(
-        index: _currentIndex,
-        children: _screens,
-      ),
-      bottomNavigationBar: BottomNavigationBar(
-        backgroundColor: Colors.white, // Fondo blanco del navbar
-        currentIndex: _currentIndex,
-        onTap: (index) => setState(() => _currentIndex = index),
-        type: BottomNavigationBarType.fixed,
-        selectedItemColor: Colors.blue, // Ítem activo (círculo azul)
-        unselectedItemColor: Colors.grey[700],
-        showUnselectedLabels: true,
-        items: const [
-          BottomNavigationBarItem(
-            icon: Icon(Icons.home_outlined),
-            activeIcon: Icon(Icons.home),
-            label: 'Home',
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.sports_soccer_outlined),
-            activeIcon: Icon(Icons.sports_soccer),
-            label: 'Partidos',
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.fact_check_outlined),
-            activeIcon:Icon(Icons.fact_check),
-            label: 'Ranking',
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.history_outlined),
-            activeIcon: Icon(Icons.history),
-            label: 'Historial',
-          ),
-          BottomNavigationBarItem(
-            icon:  Icon(Icons.person_outline),
-            activeIcon:Icon(Icons.person),
-            label: 'Perfil',
-          ),
-        ],
+    return BlocProvider(
+      create: (_) => sl<LeaguesBloc>()..add(LoadLeaguesRequested()),
+      child: Scaffold(
+        backgroundColor: Colors.white, // Fondo blanco total
+        body: IndexedStack(
+          index: _currentIndex,
+          children: _screens,
+        ),
+        bottomNavigationBar: BottomNavigationBar(
+          backgroundColor: Colors.white, // Fondo blanco del navbar
+          currentIndex: _currentIndex,
+          onTap: (index) => setState(() => _currentIndex = index),
+          type: BottomNavigationBarType.fixed,
+          selectedItemColor: Colors.blue, // Ítem activo (círculo azul)
+          unselectedItemColor: Colors.grey[700],
+          showUnselectedLabels: true,
+          items: const [
+            BottomNavigationBarItem(
+              icon: Icon(Icons.home_outlined),
+              activeIcon: Icon(Icons.home),
+              label: 'Home',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.sports_soccer_outlined),
+              activeIcon: Icon(Icons.sports_soccer),
+              label: 'Partidos',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.fact_check_outlined),
+              activeIcon:Icon(Icons.fact_check),
+              label: 'Ranking',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.history_outlined),
+              activeIcon: Icon(Icons.history),
+              label: 'Historial',
+            ),
+            BottomNavigationBarItem(
+              icon:  Icon(Icons.person_outline),
+              activeIcon:Icon(Icons.person),
+              label: 'Perfil',
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/home/ui/screens/home_screen.dart
+++ b/lib/features/home/ui/screens/home_screen.dart
@@ -1,11 +1,26 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../leagues/ui/blocs/leagues_bloc/leagues_bloc.dart';
+import '../../../leagues/ui/screens/create_league_screen.dart';
 import '../../../../core/widgets/history_card.dart';
 import '../../../../core/widgets/match_card.dart';
 import '../../../../core/widgets/new_card.dart';
 import '../../../../core/widgets/section_title.dart';
 
-class HomeScreen extends StatelessWidget {
+class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  @override
+  void initState() {
+    super.initState();
+    context.read<LeaguesBloc>().add(LoadLeaguesRequested());
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -18,16 +33,55 @@ class HomeScreen extends StatelessWidget {
           AppBar(
             backgroundColor: Colors.blue,
             elevation: 0,
-            title: const Text(
-              'Liga FutMatch',
-              style: TextStyle(
-                color: Colors.white,
-                fontWeight: FontWeight.bold,
-                fontSize: 20,
-              ),
+            title: BlocBuilder<LeaguesBloc, LeaguesState>(
+              builder: (context, state) {
+                final bloc = context.read<LeaguesBloc>();
+                final leagues = bloc.leagues;
+                final name = bloc.selectedLeague?.name ?? 'Liga FutMatch';
+                return Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      name,
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontWeight: FontWeight.bold,
+                        fontSize: 20,
+                      ),
+                    ),
+                    if (leagues.isNotEmpty)
+                      PopupMenuButton<League>(
+                        icon: const Icon(Icons.arrow_drop_down,
+                            color: Colors.white),
+                        onSelected: (l) => context
+                            .read<LeaguesBloc>()
+                            .add(SelectLeagueRequested(l)),
+                        itemBuilder: (_) => [
+                          for (final l in leagues)
+                            PopupMenuItem(value: l, child: Text(l.name))
+                        ],
+                      ),
+                  ],
+                );
+              },
             ),
             centerTitle: true,
             automaticallyImplyLeading: false,
+            actions: [
+              IconButton(
+                icon: const Icon(Icons.add),
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (_) => BlocProvider.value(
+                        value: context.read<LeaguesBloc>(),
+                        child: const CreateLeagueScreen(),
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ],
           ),
           // Cuerpo redondeado blanco
           Expanded(

--- a/lib/features/leagues/ui/blocs/leagues_bloc/leagues_bloc.dart
+++ b/lib/features/leagues/ui/blocs/leagues_bloc/leagues_bloc.dart
@@ -5,6 +5,7 @@ import '../../../../auth/data/datasources/auth_local_datasource.dart';
 import '../../../domain/entities/league.dart';
 import '../../../domain/usecases/create_league.dart';
 import '../../../domain/usecases/join_league.dart';
+import '../../../domain/usecases/get_leagues_for_user.dart';
 
 part 'leagues_event.dart';
 part 'leagues_state.dart';
@@ -12,15 +13,25 @@ part 'leagues_state.dart';
 class LeaguesBloc extends Bloc<LeaguesEvent, LeaguesState> {
   final CreateLeague createLeague;
   final JoinLeague joinLeague;
+  final GetLeaguesForUser getLeaguesForUser;
   final AuthLocalDataSource localDataSource;
+
+  final List<League> _leagues = [];
+  League? _selectedLeague;
+
+  List<League> get leagues => List.unmodifiable(_leagues);
+  League? get selectedLeague => _selectedLeague;
 
   LeaguesBloc({
     required this.createLeague,
     required this.joinLeague,
+    required this.getLeaguesForUser,
     required this.localDataSource,
   }) : super(LeaguesInitial()) {
     on<CreateLeagueRequested>(_onCreate);
     on<JoinLeagueRequested>(_onJoin);
+    on<LoadLeaguesRequested>(_onLoad);
+    on<SelectLeagueRequested>(_onSelect);
   }
 
   Future<void> _onCreate(
@@ -34,7 +45,10 @@ class LeaguesBloc extends Bloc<LeaguesEvent, LeaguesState> {
         {'name': event.name, 'createdBy': userId},
         tokens.accessToken,
       );
+      _leagues.add(league);
+      _selectedLeague = league;
       emit(LeagueLoaded(league));
+      emit(LeaguesListLoaded(List.unmodifiable(_leagues), _selectedLeague));
     } catch (e) {
       emit(LeaguesError(e.toString()));
     }
@@ -52,10 +66,39 @@ class LeaguesBloc extends Bloc<LeaguesEvent, LeaguesState> {
         {'userId': userId},
         tokens.accessToken,
       );
+      _leagues.add(league);
+      _selectedLeague = league;
       emit(LeagueLoaded(league));
+      emit(LeaguesListLoaded(List.unmodifiable(_leagues), _selectedLeague));
     } catch (e) {
       emit(LeaguesError(e.toString()));
     }
+  }
+
+  Future<void> _onLoad(
+      LoadLeaguesRequested event, Emitter<LeaguesState> emit) async {
+    emit(LeaguesLoading());
+    try {
+      final tokens = await localDataSource.getTokens();
+      if (tokens == null) throw Exception('Sesión no encontrada');
+      final userId = _extractUserIdFromToken(tokens.accessToken);
+      final leagues = await getLeaguesForUser(userId, tokens.accessToken);
+      _leagues
+        ..clear()
+        ..addAll(leagues);
+      if (_leagues.isNotEmpty) {
+        _selectedLeague = _leagues.first;
+      }
+      emit(LeaguesListLoaded(List.unmodifiable(_leagues), _selectedLeague));
+    } catch (e) {
+      emit(LeaguesError(e.toString()));
+    }
+  }
+
+  void _onSelect(
+      SelectLeagueRequested event, Emitter<LeaguesState> emit) {
+    _selectedLeague = event.league;
+    emit(LeaguesListLoaded(List.unmodifiable(_leagues), _selectedLeague));
   }
 
   String _extractUserIdFromToken(String token) {

--- a/lib/features/leagues/ui/blocs/leagues_bloc/leagues_event.dart
+++ b/lib/features/leagues/ui/blocs/leagues_bloc/leagues_event.dart
@@ -11,3 +11,10 @@ class JoinLeagueRequested extends LeaguesEvent {
   final String leagueId;
   JoinLeagueRequested(this.leagueId);
 }
+
+class LoadLeaguesRequested extends LeaguesEvent {}
+
+class SelectLeagueRequested extends LeaguesEvent {
+  final League league;
+  SelectLeagueRequested(this.league);
+}

--- a/lib/features/leagues/ui/blocs/leagues_bloc/leagues_state.dart
+++ b/lib/features/leagues/ui/blocs/leagues_bloc/leagues_state.dart
@@ -11,6 +11,12 @@ class LeagueLoaded extends LeaguesState {
   LeagueLoaded(this.league);
 }
 
+class LeaguesListLoaded extends LeaguesState {
+  final List<League> leagues;
+  final League? selected;
+  LeaguesListLoaded(this.leagues, this.selected);
+}
+
 class LeaguesError extends LeaguesState {
   final String message;
   LeaguesError(this.message);

--- a/lib/features/leagues/ui/screens/create_league_screen.dart
+++ b/lib/features/leagues/ui/screens/create_league_screen.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../../core/styles/input_decoration.dart';
+import '../blocs/leagues_bloc/leagues_bloc.dart';
+
+class CreateLeagueScreen extends StatefulWidget {
+  const CreateLeagueScreen({super.key});
+
+  @override
+  State<CreateLeagueScreen> createState() => _CreateLeagueScreenState();
+}
+
+class _CreateLeagueScreenState extends State<CreateLeagueScreen> {
+  final _nameCtrl = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider.value(
+      value: context.read<LeaguesBloc>(),
+      child: BlocConsumer<LeaguesBloc, LeaguesState>(
+        listener: (context, state) {
+          if (state is LeagueLoaded) {
+            Navigator.of(context).pop();
+          } else if (state is LeaguesError) {
+            ScaffoldMessenger.of(context)
+                .showSnackBar(SnackBar(content: Text(state.message)));
+          }
+        },
+        builder: (context, state) {
+          final loading = state is LeaguesLoading;
+          return Scaffold(
+            appBar: AppBar(
+              backgroundColor: Colors.blue,
+              title: const Text('Crear liga'),
+            ),
+            body: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                children: [
+                  TextField(
+                    controller: _nameCtrl,
+                    decoration: customInputDecoration('Nombre de la liga'),
+                  ),
+                  const SizedBox(height: 24),
+                  ElevatedButton(
+                    onPressed: loading
+                        ? null
+                        : () {
+                            context
+                                .read<LeaguesBloc>()
+                                .add(CreateLeagueRequested(_nameCtrl.text));
+                          },
+                    child: Text(loading ? 'Creando...' : 'Crear'),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add leagues list and selection events
- show selected league on home
- enable league creation workflow

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855e64de4ac832cbabc0613419a1273