### PR TITLE
Add back navigation for league selection

### DIFF
--- a/lib/core/routes/routes.dart
+++ b/lib/core/routes/routes.dart
@@ -4,12 +4,10 @@ import 'package:futmatch_frontend/core/widgets/main_navbar.dart';
 import '../../features/app_context/ui/screens/splash_screen.dart';
 import '../../features/leagues/ui/screens/league_selection_screen.dart';
 import '../../features/auth/ui/screens/login_screen.dart';
-import '../../features/leagues/ui/screens/create_league_screen.dart';
 
 Map<String, Widget Function(BuildContext)> routes = {
   '/': (context) => const SplashScreen(),
   '/login': (context) => LoginScreen(),
   '/home': (context) => const MainNavbar(),
   '/league-selection': (context) => const LeagueSelectionScreen(),
-  '/create-league': (context) => const CreateLeagueScreen(),
 };

--- a/lib/features/home/ui/screens/home_screen.dart
+++ b/lib/features/home/ui/screens/home_screen.dart
@@ -76,7 +76,7 @@ class _HomeScreenState extends State<HomeScreen> {
                     MaterialPageRoute(
                       builder: (_) => BlocProvider.value(
                         value: context.read<LeaguesBloc>(),
-                        child: const LeagueSelectionScreen(),
+                        child: const LeagueSelectionScreen(showBackButton: true),
                       ),
                     ),
                   );

--- a/lib/features/leagues/ui/screens/league_selection_screen.dart
+++ b/lib/features/leagues/ui/screens/league_selection_screen.dart
@@ -8,7 +8,9 @@ import '../../../../core/widgets/fut_button.dart';
 import '../blocs/leagues_bloc/leagues_bloc.dart';
 
 class LeagueSelectionScreen extends StatelessWidget {
-  const LeagueSelectionScreen({super.key});
+  final bool showBackButton;
+
+  const LeagueSelectionScreen({super.key, this.showBackButton = false});
 
   @override
   Widget build(BuildContext context) {
@@ -53,6 +55,14 @@ class LeagueSelectionScreen extends StatelessWidget {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.stretch,
                       children: [
+                        if (showBackButton)
+                          Align(
+                            alignment: Alignment.centerLeft,
+                            child: IconButton(
+                              icon: const Icon(Icons.arrow_back),
+                              onPressed: () => Navigator.of(context).pop(),
+                            ),
+                          ),
                         const Icon(Icons.sports_soccer, size: 48, color: Colors.blue),
                         const SizedBox(height: 16),
                         const Text(


### PR DESCRIPTION
## Summary
- add optional back navigation to `LeagueSelectionScreen`
- remove obsolete `CreateLeagueScreen` route
- show back button when opening league selection from home

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855e9804b9c832c91612d969d9c83d3