### PR TITLE
Add date picker bottom sheet

### DIFF
--- a/lib/features/matches/ui/screens/create_match_screen.dart
+++ b/lib/features/matches/ui/screens/create_match_screen.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:intl/intl.dart';
 import 'package:futmatch_frontend/core/widgets/fut_button.dart';
 
 import '../../../../core/styles/input_decoration.dart';
 import '../blocs/matches_bloc/matches_bloc.dart';
+import '../widgets/date_time_picker_bottom_sheet.dart';
 
 class CreateMatchScreen extends StatefulWidget {
   CreateMatchScreen({super.key});
@@ -16,6 +18,7 @@ class _CreateMatchScreenState extends State<CreateMatchScreen> {
   final _homeCtrl = TextEditingController();
   final _awayCtrl = TextEditingController();
   final _locationCtrl = TextEditingController();
+  final _dateCtrl = TextEditingController();
   DateTime? _selectedDate;
 
   @override
@@ -77,6 +80,25 @@ class _CreateMatchScreenState extends State<CreateMatchScreen> {
                       TextField(
                         controller: _locationCtrl,
                         decoration: customInputDecoration('Ubicación'),
+                      ),
+                      const SizedBox(height: 12),
+                      TextField(
+                        controller: _dateCtrl,
+                        readOnly: true,
+                        decoration: customInputDecoration('Fecha y hora'),
+                        onTap: () async {
+                          final date = await showDateTimePickerBottomSheet(
+                            context,
+                            initialDate: _selectedDate,
+                          );
+                          if (date != null) {
+                            setState(() {
+                              _selectedDate = date;
+                              _dateCtrl.text =
+                                  DateFormat('yyyy-MM-dd HH:mm').format(date);
+                            });
+                          }
+                        },
                       ),
                       const SizedBox(height: 12),
                       const SizedBox(height: 24),

--- a/lib/features/matches/ui/widgets/date_time_picker_bottom_sheet.dart
+++ b/lib/features/matches/ui/widgets/date_time_picker_bottom_sheet.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+Future<DateTime?> showDateTimePickerBottomSheet(
+  BuildContext context, {
+  DateTime? initialDate,
+}) {
+  return showModalBottomSheet<DateTime>(
+    context: context,
+    builder: (ctx) {
+      DateTime selectedDate = initialDate ?? DateTime.now();
+      TimeOfDay selectedTime = TimeOfDay.fromDateTime(selectedDate);
+      return StatefulBuilder(
+        builder: (context, setState) {
+          return SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    'Selecciona fecha y hora',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: 8),
+                  CalendarDatePicker(
+                    initialDate: selectedDate,
+                    firstDate: DateTime(DateTime.now().year - 1),
+                    lastDate: DateTime(DateTime.now().year + 5),
+                    onDateChanged: (date) {
+                      setState(() {
+                        selectedDate = DateTime(
+                          date.year,
+                          date.month,
+                          date.day,
+                          selectedTime.hour,
+                          selectedTime.minute,
+                        );
+                      });
+                    },
+                  ),
+                  SizedBox(
+                    height: 180,
+                    child: CupertinoDatePicker(
+                      mode: CupertinoDatePickerMode.time,
+                      initialDateTime: DateTime(
+                        0,
+                        0,
+                        0,
+                        selectedTime.hour,
+                        selectedTime.minute,
+                      ),
+                      use24hFormat: true,
+                      onDateTimeChanged: (dt) {
+                        setState(() {
+                          selectedTime = TimeOfDay.fromDateTime(dt);
+                        });
+                      },
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  ElevatedButton(
+                    onPressed: () {
+                      final result = DateTime(
+                        selectedDate.year,
+                        selectedDate.month,
+                        selectedDate.day,
+                        selectedTime.hour,
+                        selectedTime.minute,
+                      );
+                      Navigator.of(context).pop(result);
+                    },
+                    child: const Text('Aceptar'),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- enable match creation with date/time selection via modal bottom sheet
- implement reusable bottom sheet widget for picking date and time

## Testing
- `flutter analyze` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856f11f1090832ca7f7eafac2aa65a1