### PR TITLE
Refactor create match screen

### DIFF
--- a/lib/core/di.dart
+++ b/lib/core/di.dart
@@ -26,6 +26,14 @@ import '../features/matches/domain/usecases/cancel_participation.dart';
 import '../features/matches/domain/usecases/update_match_result.dart';
 import '../features/matches/ui/blocs/matches_bloc/matches_bloc.dart';
 import 'network/token_refresher.dart';
+import '../features/fields/data/datasources/fields_remote_datasource.dart';
+import '../features/fields/data/repositories/fields_repository_impl.dart';
+import '../features/fields/domain/repositories/fields_repository.dart';
+import '../features/fields/domain/usecases/get_fields.dart';
+import '../features/players/data/datasources/players_remote_datasource.dart';
+import '../features/players/data/repositories/players_repository_impl.dart';
+import '../features/players/domain/repositories/players_repository.dart';
+import '../features/players/domain/usecases/get_current_player.dart';
 
 final sl = GetIt.instance;
 
@@ -52,6 +60,18 @@ Future<void> init() async {
       baseUrl: baseUrl,
     ),
   );
+  sl.registerLazySingleton<FieldsRemoteDataSource>(
+    () => FieldsRemoteDataSourceImpl(
+      client: sl(),
+      baseUrl: baseUrl,
+    ),
+  );
+  sl.registerLazySingleton<PlayersRemoteDataSource>(
+    () => PlayersRemoteDataSourceImpl(
+      client: sl(),
+      baseUrl: baseUrl,
+    ),
+  );
   sl.registerLazySingleton<AuthLocalDataSource>(() => AuthLocalDataSource());
 
   // Repository
@@ -69,6 +89,12 @@ Future<void> init() async {
   sl.registerLazySingleton<LeaguesRepository>(
       () => LeaguesRepositoryImpl(sl()),
   );
+  sl.registerLazySingleton<FieldsRepository>(
+      () => FieldsRepositoryImpl(sl(), sl()),
+  );
+  sl.registerLazySingleton<PlayersRepository>(
+      () => PlayersRepositoryImpl(sl(), sl()),
+  );
 
   // Use cases
   sl.registerLazySingleton(() => LoginUser(sl()));
@@ -80,6 +106,8 @@ Future<void> init() async {
   sl.registerLazySingleton(() => GetLeaguesForUser(sl()));
   sl.registerLazySingleton(() => CreateLeague(sl()));
   sl.registerLazySingleton(() => JoinLeague(sl()));
+  sl.registerLazySingleton(() => GetFields(sl()));
+  sl.registerLazySingleton(() => GetCurrentPlayer(sl()));
 
   // Blocs
   sl.registerFactory(() => AuthBloc(loginUser: sl<LoginUser>()));

--- a/lib/features/fields/data/datasources/fields_remote_datasource.dart
+++ b/lib/features/fields/data/datasources/fields_remote_datasource.dart
@@ -1,0 +1,28 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+import '../models/field_model.dart';
+
+abstract class FieldsRemoteDataSource {
+  Future<List<FieldModel>> getFields(String token);
+}
+
+class FieldsRemoteDataSourceImpl implements FieldsRemoteDataSource {
+  final http.Client client;
+  final String baseUrl;
+
+  FieldsRemoteDataSourceImpl({required this.client, required this.baseUrl});
+
+  @override
+  Future<List<FieldModel>> getFields(String token) async {
+    final url = Uri.parse('$baseUrl/fields');
+    final response = await client.get(url, headers: {
+      'Authorization': 'Bearer $token',
+    });
+    if (response.statusCode != 200) {
+      throw Exception('Error al obtener canchas: ${response.body}');
+    }
+    final data = jsonDecode(response.body) as List<dynamic>;
+    return data.map((e) => FieldModel.fromJson(e)).toList();
+  }
+}

--- a/lib/features/fields/data/models/field_model.dart
+++ b/lib/features/fields/data/models/field_model.dart
@@ -1,0 +1,19 @@
+import '../../domain/entities/field.dart';
+
+class FieldModel extends Field {
+  FieldModel({
+    required super.id,
+    required super.name,
+    required super.location,
+    required super.courts,
+  });
+
+  factory FieldModel.fromJson(Map<String, dynamic> json) {
+    return FieldModel(
+      id: json['id'],
+      name: json['name'],
+      location: json['location'],
+      courts: json['courts'],
+    );
+  }
+}

--- a/lib/features/fields/data/repositories/fields_repository_impl.dart
+++ b/lib/features/fields/data/repositories/fields_repository_impl.dart
@@ -1,0 +1,23 @@
+import '../../../auth/data/datasources/auth_local_datasource.dart';
+import '../../domain/entities/field.dart';
+import '../../domain/repositories/fields_repository.dart';
+import '../datasources/fields_remote_datasource.dart';
+
+class FieldsRepositoryImpl implements FieldsRepository {
+  final FieldsRemoteDataSource remoteDataSource;
+  final AuthLocalDataSource localDataSource;
+
+  FieldsRepositoryImpl(this.remoteDataSource, this.localDataSource);
+
+  Future<String> _getToken() async {
+    final tokens = await localDataSource.getTokens();
+    if (tokens == null) throw Exception('Usuario no autenticado');
+    return tokens.accessToken;
+  }
+
+  @override
+  Future<List<Field>> getFields() async {
+    final token = await _getToken();
+    return remoteDataSource.getFields(token);
+  }
+}

--- a/lib/features/fields/domain/entities/field.dart
+++ b/lib/features/fields/domain/entities/field.dart
@@ -1,0 +1,13 @@
+class Field {
+  final String id;
+  final String name;
+  final String location;
+  final int courts;
+
+  Field({
+    required this.id,
+    required this.name,
+    required this.location,
+    required this.courts,
+  });
+}

--- a/lib/features/fields/domain/repositories/fields_repository.dart
+++ b/lib/features/fields/domain/repositories/fields_repository.dart
@@ -1,0 +1,5 @@
+import '../entities/field.dart';
+
+abstract class FieldsRepository {
+  Future<List<Field>> getFields();
+}

--- a/lib/features/fields/domain/usecases/get_fields.dart
+++ b/lib/features/fields/domain/usecases/get_fields.dart
@@ -1,0 +1,9 @@
+import '../entities/field.dart';
+import '../repositories/fields_repository.dart';
+
+class GetFields {
+  final FieldsRepository repository;
+  GetFields(this.repository);
+
+  Future<List<Field>> call() => repository.getFields();
+}

--- a/lib/features/matches/ui/screens/create_match_screen.dart
+++ b/lib/features/matches/ui/screens/create_match_screen.dart
@@ -1,177 +1,27 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:intl/intl.dart';
 
 import '../../../../core/di.dart';
-import '../../../../core/styles/input_decoration.dart';
-import '../../../auth/data/datasources/auth_local_datasource.dart';
 import '../../../leagues/ui/blocs/leagues_bloc/leagues_bloc.dart';
-import '../../../fields/domain/entities/field.dart';
-import '../../../fields/domain/usecases/get_fields.dart';
-import '../../../players/domain/usecases/get_current_player.dart';
 import '../blocs/matches_bloc/matches_bloc.dart';
-import '../widgets/date_time_picker_bottom_sheet.dart';
+import '../widgets/create_match_content.dart';
 
-class CreateMatchScreen extends StatefulWidget {
-  CreateMatchScreen({super.key});
 
-  @override
-  State<CreateMatchScreen> createState() => _CreateMatchScreenState();
-}
-
-class _CreateMatchScreenState extends State<CreateMatchScreen> {
-  final _dateCtrl = TextEditingController();
-
-  final List<Field> _fields = [];
-  Field? _selectedField;
-  int _teamSize = 5;
-  String? _playerId;
-  DateTime? _selectedDate;
-
-  @override
-  void initState() {
-    super.initState();
-    _loadInitialData();
-  }
-
-  Future<void> _loadInitialData() async {
-    final local = sl<AuthLocalDataSource>();
-    final tokens = await local.getTokens();
-    if (tokens == null) return;
-
-    try {
-      final fields = await sl<GetFields>()();
-      final player = await sl<GetCurrentPlayer>()();
-      setState(() {
-        _fields
-          ..clear()
-          ..addAll(fields);
-        if (_fields.isNotEmpty) _selectedField = _fields.first;
-        _playerId = player.id;
-      });
-    } catch (_) {
-      // ignore errors in initial load
-    }
-  }
-
+class CreateMatchScreen extends StatelessWidget {
+  const CreateMatchScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.white,
-      body: Column(
-        children: [
-          AppBar(
-            backgroundColor: Colors.blue,
-            elevation: 0,
-            title: const Text(
-              'Liga FutMatch',
-              style: TextStyle(
-                color: Colors.white,
-                fontWeight: FontWeight.bold,
-                fontSize: 20,
-              ),
-            ),
-            centerTitle: true,
-            automaticallyImplyLeading: false,
-          ),
-          Expanded(
-            child: Container(
-              width: double.infinity,
-              decoration: const BoxDecoration(
-                color: Color(0xFFFFFFFF),
-                borderRadius: BorderRadius.only(
-                  topLeft: Radius.circular(28),
-                  topRight: Radius.circular(28),
-                ),
-              ),
-              padding: const EdgeInsets.all(16),
-              child: BlocConsumer<MatchesBloc, MatchesState>(
-                listener: (context, state) {
-                  if (state is MatchesError) {
-                    ScaffoldMessenger.of(
-                      context,
-                    ).showSnackBar(SnackBar(content: Text(state.message)));
-                  }
-                  if (state is MatchLoaded) {
-                    Navigator.of(context).pop(state.match);
-                  }
-                },
-                builder: (context, state) {
-                  final loading = state is MatchesLoading;
-                  return Column(
-                    children: [
-                      DropdownButtonFormField<Field>(
-                        value: _selectedField,
-                        items: [
-                          for (final f in _fields)
-                            DropdownMenuItem(value: f, child: Text(f.name))
-                        ],
-                        decoration: customInputDecoration('Cancha'),
-                        onChanged: (f) => setState(() => _selectedField = f),
-                      ),
-                      const SizedBox(height: 12),
-                      DropdownButtonFormField<int>(
-                        value: _teamSize,
-                        items: const [
-                          DropdownMenuItem(value: 5, child: Text('5')),
-                          DropdownMenuItem(value: 7, child: Text('7')),
-                          DropdownMenuItem(value: 11, child: Text('11')),
-                        ],
-                        decoration: customInputDecoration('Tamaño del equipo'),
-                        onChanged: (v) => setState(() => _teamSize = v ?? 5),
-                      ),
-                      const SizedBox(height: 12),
-                      TextField(
-                        controller: _dateCtrl,
-                        readOnly: true,
-                        decoration: customInputDecoration('Fecha y hora'),
-                        onTap: () async {
-                          final date = await showDateTimePickerBottomSheet(
-                            context,
-                            initialDate: _selectedDate,
-                          );
-                          if (date != null) {
-                            setState(() {
-                              _selectedDate = date;
-                              _dateCtrl.text =
-                                  DateFormat('yyyy-MM-dd HH:mm').format(date);
-                            });
-                          }
-                        },
-                      ),
-                      const SizedBox(height: 12),
-                      const SizedBox(height: 24),
-                      FutButton(
-                        onPressed: loading
-                            ? null
-                            : () {
-                                final leagueId =
-                                    context.read<LeaguesBloc>().selectedLeague?.id;
-                                if (leagueId == null ||
-                                    _selectedField == null ||
-                                    _playerId == null) return;
-                                context.read<MatchesBloc>().add(
-                                  CreateMatchRequested({
-                                    'leagueId': leagueId,
-                                    'fieldId': _selectedField!.id,
-                                    'teamSize': _teamSize,
-                                    'createdBy': _playerId!,
-                                    'scheduledAt':
-                                        _selectedDate?.toIso8601String() ?? '',
-                                  }),
-                                );
-                              },
-                        text: loading ? 'Creando...' : 'Crear partido',
-                      )
-                    ],
-                  );
-                },
-              ),
-            ),
-          ),
-        ],
-      ),
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider<LeaguesBloc>(
+          create: (_) => sl<LeaguesBloc>()..add(LoadLeaguesRequested()), // Opcional
+        ),
+        BlocProvider<MatchesBloc>(
+          create: (_) => sl<MatchesBloc>(),
+        ),
+      ],
+      child: const CreateMatchContent(),
     );
   }
 }

--- a/lib/features/matches/ui/widgets/create_match_content.dart
+++ b/lib/features/matches/ui/widgets/create_match_content.dart
@@ -1,0 +1,186 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:intl/intl.dart';
+
+import '../../../../core/di.dart';
+import '../../../../core/styles/input_decoration.dart';
+import '../../../../core/widgets/fut_button.dart';
+import '../../../auth/data/datasources/auth_local_datasource.dart';
+import '../../../fields/domain/entities/field.dart';
+import '../../../fields/domain/usecases/get_fields.dart';
+import '../../../players/domain/usecases/get_current_player.dart';
+import '../blocs/matches_bloc/matches_bloc.dart';
+import '../../../leagues/ui/blocs/leagues_bloc/leagues_bloc.dart';
+import '../widgets/date_time_picker_bottom_sheet.dart';
+
+class CreateMatchContent extends StatefulWidget {
+  const CreateMatchContent({super.key});
+
+  @override
+  State<CreateMatchContent> createState() => _CreateMatchContentState();
+}
+
+class _CreateMatchContentState extends State<CreateMatchContent> {
+  final _dateCtrl = TextEditingController();
+
+  final List<Field> _fields = [];
+  Field? _selectedField;
+  int _teamSize = 5;
+  String? _playerId;
+  DateTime? _selectedDate;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadInitialData();
+  }
+
+  Future<void> _loadInitialData() async {
+    final local = sl<AuthLocalDataSource>();
+    final tokens = await local.getTokens();
+    if (tokens == null) return;
+
+    try {
+      final fields = await sl<GetFields>()();
+      final player = await sl<GetCurrentPlayer>()();
+      setState(() {
+        _fields
+          ..clear()
+          ..addAll(fields);
+        if (_fields.isNotEmpty) _selectedField = _fields.first;
+        _playerId = player.id;
+      });
+    } catch (_) {
+      // Ignorar error de carga inicial
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      body: Column(
+        children: [
+          AppBar(
+            backgroundColor: Colors.blue,
+            elevation: 0,
+            title: const Text('Liga FutMatch',
+                style: TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
+                    fontSize: 20)),
+            centerTitle: true,
+            automaticallyImplyLeading: false,
+          ),
+          Expanded(
+            child: Container(
+              width: double.infinity,
+              decoration: const BoxDecoration(
+                color: Color(0xFFFFFFFF),
+                borderRadius: BorderRadius.only(
+                  topLeft: Radius.circular(28),
+                  topRight: Radius.circular(28),
+                ),
+              ),
+              padding: const EdgeInsets.all(16),
+              child: BlocConsumer<MatchesBloc, MatchesState>(
+                listener: (context, state) {
+                  if (state is MatchesError) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(content: Text(state.message)),
+                    );
+                  }
+                  if (state is MatchLoaded) {
+                    Navigator.of(context).pop(state.match);
+                  }
+                },
+                builder: (context, state) {
+                  final loading = state is MatchesLoading;
+                  return Column(
+                    children: [
+                      DropdownButtonFormField<Field>(
+                        value: _selectedField,
+                        items: [
+                          for (final f in _fields)
+                            DropdownMenuItem(value: f, child: Text(f.name))
+                        ],
+                        decoration: customInputDecoration('Cancha'),
+                        onChanged: (f) => setState(() => _selectedField = f),
+                      ),
+                      const SizedBox(height: 12),
+                      DropdownButtonFormField<int>(
+                        value: _teamSize,
+                        items: const [
+                          DropdownMenuItem(value: 5, child: Text('5')),
+                          DropdownMenuItem(value: 7, child: Text('7')),
+                          DropdownMenuItem(value: 11, child: Text('11')),
+                        ],
+                        decoration: customInputDecoration('Tamaño del equipo'),
+                        onChanged: (v) => setState(() => _teamSize = v ?? 5),
+                      ),
+                      const SizedBox(height: 12),
+                      TextField(
+                        controller: _dateCtrl,
+                        readOnly: true,
+                        decoration: customInputDecoration('Fecha y hora'),
+                        onTap: () async {
+                          final date = await showDateTimePickerBottomSheet(
+                            context,
+                            initialDate: _selectedDate,
+                          );
+                          if (date != null) {
+                            setState(() {
+                              _selectedDate = date;
+                              _dateCtrl.text =
+                                  DateFormat('yyyy-MM-dd HH:mm').format(date);
+                            });
+                          }
+                        },
+                      ),
+                      const SizedBox(height: 24),
+                      FutButton(
+                        onPressed: loading
+                            ? null
+                            : () {
+                          final leagueId = context
+                              .read<LeaguesBloc>()
+                              .selectedLeague
+                              ?.id;
+
+                          if (leagueId == null ||
+                              _selectedField == null ||
+                              _playerId == null) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(
+                                content:
+                                Text('Completa todos los campos'),
+                              ),
+                            );
+                            return;
+                          }
+
+                          context.read<MatchesBloc>().add(
+                            CreateMatchRequested({
+                              'leagueId': leagueId,
+                              'fieldId': _selectedField!.id,
+                              'teamSize': _teamSize,
+                              'createdBy': _playerId!,
+                              'scheduledAt': _selectedDate
+                                  ?.toIso8601String() ??
+                                  '',
+                            }),
+                          );
+                        },
+                        text: loading ? 'Creando...' : 'Crear partido',
+                      )
+                    ],
+                  );
+                },
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/players/data/datasources/players_remote_datasource.dart
+++ b/lib/features/players/data/datasources/players_remote_datasource.dart
@@ -1,0 +1,27 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+import '../models/player_model.dart';
+
+abstract class PlayersRemoteDataSource {
+  Future<PlayerModel> getCurrentPlayer(String userId, String token);
+}
+
+class PlayersRemoteDataSourceImpl implements PlayersRemoteDataSource {
+  final http.Client client;
+  final String baseUrl;
+
+  PlayersRemoteDataSourceImpl({required this.client, required this.baseUrl});
+
+  @override
+  Future<PlayerModel> getCurrentPlayer(String userId, String token) async {
+    final url = Uri.parse('$baseUrl/users/$userId/player');
+    final response = await client.get(url, headers: {
+      'Authorization': 'Bearer $token',
+    });
+    if (response.statusCode != 200) {
+      throw Exception('Error al obtener jugador: ${response.body}');
+    }
+    return PlayerModel.fromJson(jsonDecode(response.body));
+  }
+}

--- a/lib/features/players/data/models/player_model.dart
+++ b/lib/features/players/data/models/player_model.dart
@@ -1,0 +1,23 @@
+import '../../domain/entities/player.dart';
+
+class PlayerModel extends Player {
+  PlayerModel({
+    required super.id,
+    required super.name,
+    required super.age,
+    required super.positions,
+    required super.avatar,
+    required super.rating,
+  });
+
+  factory PlayerModel.fromJson(Map<String, dynamic> json) {
+    return PlayerModel(
+      id: json['id'],
+      name: json['name'],
+      age: json['age'],
+      positions: List<String>.from(json['positions'] ?? []),
+      avatar: json['avatar'],
+      rating: json['rating'],
+    );
+  }
+}

--- a/lib/features/players/data/repositories/players_repository_impl.dart
+++ b/lib/features/players/data/repositories/players_repository_impl.dart
@@ -1,0 +1,34 @@
+import 'dart:convert';
+
+import '../../../auth/data/datasources/auth_local_datasource.dart';
+import '../../domain/entities/player.dart';
+import '../../domain/repositories/players_repository.dart';
+import '../datasources/players_remote_datasource.dart';
+
+class PlayersRepositoryImpl implements PlayersRepository {
+  final PlayersRemoteDataSource remoteDataSource;
+  final AuthLocalDataSource localDataSource;
+
+  PlayersRepositoryImpl(this.remoteDataSource, this.localDataSource);
+
+  Future<String> _getToken() async {
+    final tokens = await localDataSource.getTokens();
+    if (tokens == null) throw Exception('Usuario no autenticado');
+    return tokens.accessToken;
+  }
+
+  String _extractUserIdFromToken(String token) {
+    final parts = token.split('.');
+    if (parts.length != 3) throw Exception('Token inválido');
+    final payload = utf8.decode(base64Url.decode(base64Url.normalize(parts[1])));
+    final decoded = jsonDecode(payload) as Map<String, dynamic>;
+    return decoded['sub'] as String;
+  }
+
+  @override
+  Future<Player> getCurrentPlayer() async {
+    final token = await _getToken();
+    final userId = _extractUserIdFromToken(token);
+    return remoteDataSource.getCurrentPlayer(userId, token);
+  }
+}

--- a/lib/features/players/domain/entities/player.dart
+++ b/lib/features/players/domain/entities/player.dart
@@ -1,0 +1,17 @@
+class Player {
+  final String id;
+  final String name;
+  final int age;
+  final List<String> positions;
+  final String avatar;
+  final int rating;
+
+  Player({
+    required this.id,
+    required this.name,
+    required this.age,
+    required this.positions,
+    required this.avatar,
+    required this.rating,
+  });
+}

--- a/lib/features/players/domain/repositories/players_repository.dart
+++ b/lib/features/players/domain/repositories/players_repository.dart
@@ -1,0 +1,5 @@
+import '../entities/player.dart';
+
+abstract class PlayersRepository {
+  Future<Player> getCurrentPlayer();
+}

--- a/lib/features/players/domain/usecases/get_current_player.dart
+++ b/lib/features/players/domain/usecases/get_current_player.dart
@@ -1,0 +1,9 @@
+import '../entities/player.dart';
+import '../repositories/players_repository.dart';
+
+class GetCurrentPlayer {
+  final PlayersRepository repository;
+  GetCurrentPlayer(this.repository);
+
+  Future<Player> call() => repository.getCurrentPlayer();
+}


### PR DESCRIPTION
## Summary
- fetch fields and player for creating matches
- capture field and team size via dropdowns
- automatically set createdBy from the logged in player

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685703998584832ca0a66bd6ac9287d0